### PR TITLE
Make source sidekick disappear at end

### DIFF
--- a/lib/src/widgets/sidekick.dart
+++ b/lib/src/widgets/sidekick.dart
@@ -357,7 +357,6 @@ class _SidekickFlight {
       overlayEntry.remove();
       overlayEntry = null;
 
-      manifest.fromSidekick.endFlight();
       manifest.toSidekick.endFlight();
       onFlightEnded(this);
     }


### PR DESCRIPTION
I suspect because this code was borrowed from the Hero animation, currently the source and the target Sidekick appear after the animation completes. This is probably not what you want -- and it's not the behavior of the sidekick team -- normally you want it to seem like it has flown from one place to another. 

Making this one line change fixes that. :-)