### PR TITLE
add param to keep showing from widget after flight

### DIFF
--- a/test/flutter_sidekick_test.dart
+++ b/test/flutter_sidekick_test.dart
@@ -10,9 +10,11 @@ class SimpleExample extends StatefulWidget {
   SimpleExample([
     this.sourceTag = 'source',
     this.targetTag = 'target',
+    this.keepShowingSource = false,
   ]);
   final String sourceTag;
   final String targetTag;
+  final bool keepShowingSource;
 
   @override
   _SimpleExampleState createState() => _SimpleExampleState();
@@ -51,6 +53,7 @@ class _SimpleExampleState extends State<SimpleExample>
               child: Sidekick(
                 tag: widget.sourceTag,
                 targetTag: widget.targetTag,
+                keepShowingWidget: widget.keepShowingSource,
                 child: Container(
                   key: simpleSource,
                   color: Colors.blue,
@@ -246,6 +249,39 @@ void main() {
 
       // t=1.033s for the journey. The journey has ended (it ends this frame, in
       // fact). The sidekicks should be back now.
+      expect(find.byKey(simpleTarget), isInCard);
+    });
+
+    testWidgets('Animate to target with keepShowing source',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+          MaterialApp(home: SimpleExample('source', 'target', true)));
+
+      // the initial setup.
+      expect(find.byKey(simpleSource), isInCard);
+      expect(find.byKey(simpleTarget), isInCard);
+
+      await tester.tap(find.byKey(simpleSource));
+      await tester.pump(); // the animation will start at the next frame.
+      await tester.pump(frameDuration);
+
+      // at this stage, the sidekick just gone on its journey, we are
+      // seeing them at t=16ms.
+
+      expect(find.byKey(simpleSource), findsNothing);
+      expect(find.byKey(simpleTarget), isNotInCard);
+
+      await tester.pump(frameDuration);
+
+      // t=32ms for the journey. Surely they are still at it.
+      expect(find.byKey(simpleSource), findsNothing);
+      expect(find.byKey(simpleTarget), isNotInCard);
+
+      await tester.pump(const Duration(seconds: 1));
+
+      // t=1.033s for the journey. The journey has ended (it ends this frame, in
+      // fact). The sidekicks should be back now.
+      expect(find.byKey(simpleSource), isInCard);
       expect(find.byKey(simpleTarget), isInCard);
     });
 


### PR DESCRIPTION
This PR adds a new param to use with the source "from" Sidekick widget to allow choosing to keep showing the original source widget. 

My thanks to @efortuna for submitting the bugfix that this PR essentially optionally disables as otherwise I would not have realised this functionality was possible with Sidekick.

The reason I want to be able to do this is to use Sidekick to implement an animation which temporarily replaces the target widget, as shown in the video below.

ps. My apologies for the laggyness at the end of the animation in the video, that just seems to be due to recording on the emulator, the actual animation is nice and smooth.

![sidekick-pr webm](https://user-images.githubusercontent.com/48809901/57116620-a1979300-6d99-11e9-939a-fde7b3b37a11.gif)



